### PR TITLE
RDKB-60899, RDKB-56905: Specify new enums for mesh onboard bridges

### DIFF
--- a/include/bridge_util_hal.h
+++ b/include/bridge_util_hal.h
@@ -128,8 +128,10 @@ enum Config {
 	MESH_BACKHAUL = 10,					// **< Mesh Backhaul configuration
 	ETH_BACKHAUL = 11,					// **< ETH Backhaul configuration
 	MESH = 12,						// **< Mesh configuration
-	MESH_WIFI_BACKHAUL_2G = 13,			        // **< Mesh Wifi backhaul 2G configuration
-	MESH_WIFI_BACKHAUL_5G = 14			        // **< Mesh Wifi backhaul 5G configuration
+    MESH_WIFI_BACKHAUL_2G = 13,     // **< Mesh Wifi backhaul 2G configuration
+    MESH_WIFI_BACKHAUL_5G = 14,     // **< Mesh Wifi backhaul 5G configuration
+    MESH_ONBOARD = 18,              // **< Mesh Onboard configuration
+    MESH_WIFI_ONBOARD_2G = 19       // **< Mesh Wifi onboard 2G configuration
 #if defined  (WIFI_MANAGE_SUPPORTED)
         ,MANAGE_WIFI_BRIDGE = 17		                // **< Manage Wifi bridge configuration
 #endif /* WIFI_MANAGE_SUPPORTED*/


### PR DESCRIPTION
Reason for change: Specify new enums for mesh onboard bridges Test Procedure: Verify if bridgeUtils is able to create new mesh
                onboarding bridges

Change-Id: Idab885d633c375c2367d31f04120de1f0e70a14a
Priority: P1
Risks: Medium